### PR TITLE
BAH-844 | adding default zero-length value for openelis properties.

### DIFF
--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/OpenERPAtomFeedProperties.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/OpenERPAtomFeedProperties.java
@@ -38,7 +38,7 @@ public class OpenERPAtomFeedProperties implements OpenERPProperties {
     private String customFeedUri;
 
 
-    @Value("${openelis.saleorder.feed.generator.uri}")
+    @Value("${openelis.saleorder.feed.generator.uri:}")
     private String elisSaleOrderFeedUri;
 
     @Value("${drug.feed.generator.uri}")
@@ -132,21 +132,21 @@ public class OpenERPAtomFeedProperties implements OpenERPProperties {
         return openmrsAuthUri;
     }
 
-    @Value("${openelis.uri}")
+    @Value("${openelis.uri:}")
     private String openElisUri;
 
     public String getOpenElisURI() {
         return openElisUri;
     }
 
-    @Value("${openelis.user}")
+    @Value("${openelis.user:}")
     private String openElisUser;
 
     public String getOpenElisUser() {
         return openElisUser;
     }
 
-    @Value("${openelis.password}")
+    @Value("${openelis.password:}")
     private String openElisPwd;
 
     public String getOpenElisPassword() {


### PR DESCRIPTION
BAH-844 | adding default zero-length value for openelis properties. This properties are not set if bahmni-lab is not installed