### PR TITLE
Added @jsonproperty binding to OpenMRSObservation domain model

### DIFF
--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenMRSObservation.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenMRSObservation.java
@@ -1,11 +1,13 @@
 package org.bahmni.feed.openerp.domain.encounter;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenMRSObservation {
     private String orderUuid;
     private String conceptNameToDisplay;
+    @JsonProperty("valueAsString")
     private String value;
 
     public String getOrderUuid() {


### PR DESCRIPTION
Added @jsonproperty binding to OpenMRSObservation domain model to prevent observations with coded values to cause a parse error as caused by forms created using implementers interface with no grouping of concepts used. This is true when creating an observation form in implementers interface by using individual concepts with coded data types without grouping them as concept sets. In such cases, the encounter API will return the observations ungrouped and the value of those observations will be a json object (since it is a coded value). This will result in a parse error as the bind for value expects it to be a string. Since there will always be a property "valueAsString" in each observation returned by the API, it will be better to bind that to the "value" property of the OpenMRSObservation object.

To duplicate this issue:

1. create a form using implementers interface
2. add an obs control whose data type is coded
3. save the form
4. capture an observation using the form
5. look at the output from bahmni-erp-connect log

Attached is partial (relevant) output a got from bahmni-erp-connect log
[openerp-feed-service.log](https://github.com/Bahmni/openerp-atomfeed-service/files/5267757/openerp-feed-service.log)


