### PR TITLE
BAH-1184 | [Priya, Sameera] | To remove the dependabot Alerts

### DIFF
--- a/openerp-atomfeed-service/pom.xml
+++ b/openerp-atomfeed-service/pom.xml
@@ -190,9 +190,14 @@
             <version>1.6.0</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/openerp-client/pom.xml
+++ b/openerp-client/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.8.3</version>
+            <version>[1.9.4,)</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -107,9 +107,14 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <scope>provided</scope>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -125,6 +130,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.1</version>
         </dependency>
     </dependencies>
 

--- a/openerp-client/src/main/java/org/bahmni/openerp/web/client/OpenERPResponseErrorValidator.java
+++ b/openerp-client/src/main/java/org/bahmni/openerp/web/client/OpenERPResponseErrorValidator.java
@@ -1,6 +1,6 @@
 package org.bahmni.openerp.web.client;
-
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -17,7 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 public class OpenERPResponseErrorValidator {
-    private static final Logger logger = Logger.getLogger(OpenERPResponseErrorValidator.class);
+    private static final Logger logger = LogManager.getLogger(OpenERPResponseErrorValidator.class);
     private static final DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
 
     public void checkForError(String response) {

--- a/openerp-client/src/main/java/org/bahmni/openerp/web/http/client/HttpClient.java
+++ b/openerp-client/src/main/java/org/bahmni/openerp/web/http/client/HttpClient.java
@@ -1,6 +1,7 @@
 package org.bahmni.openerp.web.http.client;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -12,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 
 @Component
 public class HttpClient {
-    private static final Logger logger = Logger.getLogger(HttpClient.class);
+    private static final Logger logger = LogManager.getLogger(HttpClient.class);
     private RestTemplate restTemplate;
 
     private boolean isTimeoutSet;

--- a/openerp-client/src/main/java/org/bahmni/openerp/web/service/CustomerAccountService.java
+++ b/openerp-client/src/main/java/org/bahmni/openerp/web/service/CustomerAccountService.java
@@ -1,6 +1,7 @@
 package org.bahmni.openerp.web.service;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.bahmni.openerp.web.OpenERPException;
 import org.bahmni.openerp.web.client.OpenERPClient;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,7 +12,7 @@ import java.util.Vector;
 @Service
 public class CustomerAccountService {
     OpenERPClient openERPClient;
-    private static Logger logger = Logger.getLogger(CustomerAccountService.class);
+    private static Logger logger = LogManager.getLogger(CustomerAccountService.class);
 
 
     @Autowired

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring.version>4.1.4.RELEASE</spring.version>
+        <spring.version>4.3.20.RELEASE</spring.version>
         <cglib.version>2.2.2</cglib.version>
-        <quartz.version>2.1.7</quartz.version>
+        <quartz.version>2.3.2</quartz.version>
         <atomfeed.version>1.9.4</atomfeed.version>
         <!--<db.server>10.4.33.112</db.server>-->
         <db.server>localhost</db.server>
@@ -29,9 +29,9 @@
         <db.password>postgres</db.password>
         <db.schema>public</db.schema>
 
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.1</junit.version>
         <mockito-core.version>1.10.19</mockito-core.version>
-        <jackson.version>2.8.1</jackson.version>
+        <jackson.version>2.9.10.7</jackson.version>
         <httpcore.version>4.4.5</httpcore.version>
         <httpClient.version>4.5.2</httpClient.version>
         <servlet-api.version>3.0.1</servlet-api.version>


### PR DESCRIPTION
The following dependency version changes were made to remove the dependabot alerts.
updated  junit [4.12 to 4.13.1]
updated commons-beanutils [1.8.3 to 1.9.4]
updated log4j version 1.x to 2.x
updated spring [4.1.4 to 4.3.20]
updated quartz [2.1.7 to 2.3.2]
updated jackson [2.8.1 to 2.9.10.7]
