### PR TITLE
BAH-1184 | [Priya, Sameera] | To remove the dependabot alerts

### DIFF
--- a/openerp-client/pom.xml
+++ b/openerp-client/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.8.3</version>
+            <version>1.9.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring.version>4.1.4.RELEASE</spring.version>
+        <spring.version>4.3.20.RELEASE</spring.version>
         <cglib.version>2.2.2</cglib.version>
-        <quartz.version>2.1.7</quartz.version>
+        <quartz.version>2.3.2</quartz.version>
         <atomfeed.version>1.9.4</atomfeed.version>
         <!--<db.server>10.4.33.112</db.server>-->
         <db.server>localhost</db.server>
@@ -29,9 +29,9 @@
         <db.password>postgres</db.password>
         <db.schema>public</db.schema>
 
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.1</junit.version>
         <mockito-core.version>1.10.19</mockito-core.version>
-        <jackson.version>2.8.1</jackson.version>
+        <jackson.version>2.9.10.7</jackson.version>
         <httpcore.version>4.4.5</httpcore.version>
         <httpClient.version>4.5.2</httpClient.version>
         <servlet-api.version>3.0.1</servlet-api.version>


### PR DESCRIPTION
The following changes were made to remove the dependabot alerts.

updated junit [ 4.12 to 4.13.1 ]
updated commons-beanutils [ 1.8.3 to 1.9.4 ]
updated spring [ 4.1.4 to 4.3.20 ]
updated jackson [ 2.8.1 to 2.9.10.7 ]
updated quartz-scheduler [ 2.1.7 to 2.3.2 ]