### PR TITLE
BAH-1251 | Remove Travis CI build badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 openerp-atomfeed-service
 ========================
 
-[![Build Status](https://travis-ci.org/Bhamni/openerp-atomfeed-service.svg?branch=master)](https://travis-ci.org/Bhamni/openerp-atomfeed-service)
-
 [![Build v0.94](https://github.com/Bahmni/openerp-atomfeed-service/actions/workflows/ci-v0.94.yml/badge.svg)](https://github.com/Bahmni/openerp-atomfeed-service/actions/)
 
 Atom feed client and server interface service for OpenERP


### PR DESCRIPTION
Removing Travis CI build status badge from README which is no longer used.