### PR TITLE
BAH-1260 | Fix | Update OpenELIS URI with feed URI for authentication

### DIFF
--- a/openerp-atomfeed-service/src/main/resources/erp-atomfeed.properties
+++ b/openerp-atomfeed-service/src/main/resources/erp-atomfeed.properties
@@ -41,7 +41,7 @@ openerp.maxFailedEvents=1000
 
 openelis.user=atomfeed
 openelis.password=AdminadMIN*
-openelis.uri=http://localhost:8052/openelis
+openelis.uri=http://localhost:8052/openelis/ws/feed/patient/recent
 
 openmrs.user=admin
 openmrs.password=test


### PR DESCRIPTION
Bahmni ERP Connect failed to authenticate with OpenELIS because the URI gave a redirect instead of success response. So updated the URI with the feed URI.