### PR TITLE
BAH-2436 | Use amazoncorretto as base image

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: "corretto"
           java-version: "8"
       - name: Set env.ARTIFACT_VERSION
         run: |

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: '8'
       - name: Checkout OpenERP Atomfeed Service Repo
         uses: actions/checkout@v2

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM amazoncorretto:8
 
 ENV SERVER_PORT=8053
 ENV BASE_DIR=/var/run/bahmni-erp-connect
@@ -8,7 +8,7 @@ ENV SERVER_OPTS="-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m"
 ENV DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,address=8002,server=y,suspend=n"
 
 # Used by envsubst command for replacing environment values at runtime
-RUN apk add gettext
+RUN yum install -y gettext
 
 ADD https://repo.mybahmni.org/packages/build/bahmni-embedded-tomcat-8.0.42.jar /opt/bahmni-erp-connect/lib/bahmni-erp-connect.jar
 COPY openerp-atomfeed-service/target/openerp-atomfeed-service.war /etc/bahmni-erp-connect/openerp-atomfeed-service.war


### PR DESCRIPTION
Using amazoncorreto as baseimage since openjdk builds has beeen deprecated. More info [here](https://talk.openmrs.org/t/using-amazoncorretto-as-base-image-for-bahmni-docker-images/37668).

Co-authored-by: Divij Goyal [divij.g@beehyv.com](mailto:divij.g@beehyv.com)