### PR TITLE
BAH-3395 | Add. Bump Java Version 8 -> 11

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
           distribution: "corretto"
-          java-version: "8"
+          java-version: "11"
       - name: Set env.ARTIFACT_VERSION
         run: |
           wget -q https://raw.githubusercontent.com/Bahmni/bahmni-infra-utils/main/setArtifactVersion.sh && chmod +x setArtifactVersion.sh

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -8,11 +8,11 @@ jobs:
     name: Tests & Package
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
-          java-version: '8'
+          java-version: '11'
       - name: Checkout OpenERP Atomfeed Service Repo
         uses: actions/checkout@v2
       - name: Run Tests

--- a/openerp-atomfeed-service/pom.xml
+++ b/openerp-atomfeed-service/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.7</version>
         </dependency>
         <!-- Spring core & mvc -->
         <dependency>
@@ -184,23 +184,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity-engine-core</artifactId>
-            <version>2.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/openerp-client/pom.xml
+++ b/openerp-client/pom.xml
@@ -194,13 +194,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.0</version>
         </dependency>
         <!--test libraries-->
         <dependency>

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:8
+FROM amazoncorretto:11
 
 ENV SERVER_PORT=8053
 ENV BASE_DIR=/var/run/bahmni-erp-connect

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <packaging>pom</packaging>
     <url>http://maven.apache.org</url>
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <spring.version>5.3.30</spring.version>
         <cglib.version>2.2.2</cglib.version>
         <quartz.version>2.3.2</quartz.version>
@@ -174,13 +174,18 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-webflux</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.6</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.quartz-scheduler</groupId>


### PR DESCRIPTION
Jira -> [BAH-3395](https://bahmni.atlassian.net/browse/BAH-3395)

In this PR, the following changes are made : 

1. Upgraded Java Version from 8 to 11 for compatibility enhancements as Spring Framework 6.0, a major revision of the core framework we rely on, requires a Java 17+ baseline.
2. Removed Velocity Core dependency.
3. Added javax.annotation-api to support deprecated annotations ensuring compatibility and smooth functioning.
4. Updated Dependency Versions to address vulnerabilities and strengthen the system's security.
5. Update java version within Docker image and workflow.