### PR TITLE
BAH-3299 | Handled Inconsistent Behaviour of Quotation Updation

### DIFF
--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/MapERPOrders.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/MapERPOrders.java
@@ -64,6 +64,7 @@ public class MapERPOrders extends OpenMRSEncounterEvent {
             openERPOrder.setProductId(drugOrder.getDrugUuid());
             openERPOrder.setProductName(drugOrder.getDrugName());
             openERPOrder.setAction(drugOrder.getAction());
+            openERPOrder.setDateCreated(drugOrder.getDateActivated());
             openERPOrder.setQuantity(drugOrder.getQuantity());
             openERPOrder.setQuantityUnits(drugOrder.getQuantityUnits());
             openERPOrder.setVoided(drugOrder.isVoided());
@@ -87,6 +88,7 @@ public class MapERPOrders extends OpenMRSEncounterEvent {
             openERPOrder.setProductId(order.getConceptUuid());
             openERPOrder.setProductName(order.getConceptName());
             openERPOrder.setAction(order.getAction());
+            openERPOrder.setDateCreated(order.getDateCreated());
             openERPOrder.setQuantity((double) 1);
             openERPOrder.setQuantityUnits("Unit(s)");
             openERPOrder.setVoided(order.isVoided());

--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrder.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrder.java
@@ -1,5 +1,7 @@
 package org.bahmni.feed.openerp.domain.encounter;
 
+import java.util.Date;
+
 public class OpenERPOrder {
     private String orderId;
     private String previousOrderId;
@@ -18,6 +20,7 @@ public class OpenERPOrder {
     private String providerName;
     private String dispensed;
     private String conceptName;
+    private Date dateCreated;
 
 
     public String getEncounterId() {
@@ -51,8 +54,6 @@ public class OpenERPOrder {
     public void setType(String type) {
         this.type = type;
     }
-
-
 
     public String getDescription() {
         return description;
@@ -117,6 +118,14 @@ public class OpenERPOrder {
 
     public void setAction(String action) {
         this.action = action;
+    }
+
+    public Date getDateCreated() {
+        return dateCreated;
+    }
+
+    public void setDateCreated(Date dateCreated) {
+        this.dateCreated = dateCreated;
     }
 
     public String getPreviousOrderId() {

--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrders.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrders.java
@@ -1,6 +1,7 @@
 package org.bahmni.feed.openerp.domain.encounter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class OpenERPOrders {
@@ -21,6 +22,7 @@ public class OpenERPOrders {
             openERPOrders = new ArrayList<>();
         }
         openERPOrders.add(order);
+        Collections.sort(openERPOrders, (order1, order2) -> order1.getDateCreated().compareTo(order2.getDateCreated()));
     }
 
     public void setOpenERPOrders(List<OpenERPOrder> openERPOrders) {

--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrders.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrders.java
@@ -1,8 +1,6 @@
 package org.bahmni.feed.openerp.domain.encounter;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class OpenERPOrders {
     private String id;
@@ -14,7 +12,19 @@ public class OpenERPOrders {
     }
 
     public List<OpenERPOrder> getOpenERPOrders() {
-        return openERPOrders;
+        return removeDuplicateOrders(openERPOrders);
+    }
+
+    public List<OpenERPOrder> removeDuplicateOrders(List<OpenERPOrder> orders) {
+        Map<String, OpenERPOrder> latestOrders = new LinkedHashMap<>();
+
+        for (OpenERPOrder order : orders) {
+            latestOrders.merge(order.getProductId(), order, (existingOrder, newOrder) ->
+                    (existingOrder.getDateCreated().before(newOrder.getDateCreated())) ? newOrder : existingOrder
+            );
+        }
+
+        return new ArrayList<>(latestOrders.values());
     }
 
     public void add(OpenERPOrder order) {
@@ -22,7 +32,6 @@ public class OpenERPOrders {
             openERPOrders = new ArrayList<>();
         }
         openERPOrders.add(order);
-        Collections.sort(openERPOrders, (order1, order2) -> order1.getDateCreated().compareTo(order2.getDateCreated()));
     }
 
     public void setOpenERPOrders(List<OpenERPOrder> openERPOrders) {

--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrders.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrders.java
@@ -15,6 +15,7 @@ public class OpenERPOrders {
         return removeDuplicateOrders(openERPOrders);
     }
 
+    //Filters orders to keep only the latest action for each product. This is necessary for ensuring consistent and accurate quotation generation, particularly when order objects may not be in chronological order.
     public List<OpenERPOrder> removeDuplicateOrders(List<OpenERPOrder> orders) {
         Map<String, OpenERPOrder> latestOrders = new LinkedHashMap<>();
 

--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenMRSDrugOrder.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenMRSDrugOrder.java
@@ -3,6 +3,8 @@ package org.bahmni.feed.openerp.domain.encounter;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.util.Date;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenMRSDrugOrder {
     private OpenMRSConcept concept;
@@ -13,6 +15,7 @@ public class OpenMRSDrugOrder {
     private String uuid;
     private String previousOrderUuid;
     private String orderType;
+    private Date dateActivated;
     private boolean voided;
 
     public OpenMRSConcept getConcept() {
@@ -41,6 +44,10 @@ public class OpenMRSDrugOrder {
 
     public String getAction() {
         return action;
+    }
+
+    public Date getDateActivated() {
+        return dateActivated;
     }
 
     public String getUuid() {

--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenMRSOrder.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/domain/encounter/OpenMRSOrder.java
@@ -1,11 +1,14 @@
 package org.bahmni.feed.openerp.domain.encounter;
 
+import java.util.Date;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenMRSOrder {
     private OpenMRSConcept concept;
     private String action;
+    private Date dateCreated;
     private String uuid;
     private String orderType;
     private String orderNumber;
@@ -19,6 +22,10 @@ public class OpenMRSOrder {
 
     public String getAction() {
         return action;
+    }
+
+    public Date getDateCreated() {
+        return dateCreated;
     }
 
     public String getUuid() {

--- a/openerp-atomfeed-service/src/test/java/org/bahmni/feed/openerp/domain/encounter/MapERPOrdersTest.java
+++ b/openerp-atomfeed-service/src/test/java/org/bahmni/feed/openerp/domain/encounter/MapERPOrdersTest.java
@@ -1,4 +1,4 @@
-package org.bahmni.feed.openerp.domain.labOrderType.encounter;
+package org.bahmni.feed.openerp.domain.encounter;
 
 import org.bahmni.feed.openerp.ObjectMapperRepository;
 import org.bahmni.feed.openerp.domain.encounter.MapERPOrders;

--- a/openerp-atomfeed-service/src/test/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrdersTest.java
+++ b/openerp-atomfeed-service/src/test/java/org/bahmni/feed/openerp/domain/encounter/OpenERPOrdersTest.java
@@ -1,7 +1,5 @@
-package org.bahmni.feed.openerp.domain.labOrderType.encounter;
+package org.bahmni.feed.openerp.domain.encounter;
 
-import org.bahmni.feed.openerp.domain.encounter.OpenERPOrder;
-import org.bahmni.feed.openerp.domain.encounter.OpenERPOrders;
 import org.junit.Test;
 import java.util.Arrays;
 import java.util.Date;

--- a/openerp-atomfeed-service/src/test/java/org/bahmni/feed/openerp/domain/labOrderType/encounter/OpenERPOrdersTest.java
+++ b/openerp-atomfeed-service/src/test/java/org/bahmni/feed/openerp/domain/labOrderType/encounter/OpenERPOrdersTest.java
@@ -1,0 +1,44 @@
+package org.bahmni.feed.openerp.domain.labOrderType.encounter;
+
+import org.bahmni.feed.openerp.domain.encounter.OpenERPOrder;
+import org.bahmni.feed.openerp.domain.encounter.OpenERPOrders;
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import static org.junit.Assert.assertEquals;
+
+public class OpenERPOrdersTest {
+
+    @Test
+    public void shouldRemoveDuplicateOrders() {
+        OpenERPOrder order1 = new OpenERPOrder();
+        order1.setProductId("1");
+        order1.setDateCreated(new Date(1704718128000L));
+
+        OpenERPOrder order2 = new OpenERPOrder();
+        order2.setProductId("2");
+        order2.setDateCreated(new Date(17047181283000L));
+
+        OpenERPOrder order3 = new OpenERPOrder();
+        order3.setProductId("1");
+        order3.setDateCreated(new Date(1704718125000L));
+
+        OpenERPOrder order4 = new OpenERPOrder();
+        order4.setProductId("3");
+        order4.setDateCreated(new Date(1704718131000L));
+
+        OpenERPOrders openerpOrders = new OpenERPOrders("123");
+        openerpOrders.add(order1);
+        openerpOrders.add(order2);
+        openerpOrders.add(order3);
+        openerpOrders.add(order4);
+
+        List<OpenERPOrder> result = openerpOrders.removeDuplicateOrders(openerpOrders.getOpenERPOrders());
+
+        List<OpenERPOrder> expected = Arrays.asList(order1, order2, order4);
+
+        assertEquals(expected, result);
+    }
+}
+


### PR DESCRIPTION
PR -> [BAH-3299](https://bahmni.atlassian.net/browse/BAH-3299)

In this PR, we addressed the irregular behaviour observed when removing lab orders, where the expected reflection of the removed orders in the Odoo quotation was not consistently occurring. Odoo relies on the order in which the orders are sent, and the issue stemmed from the inconsistent ordering of the objects. To resolve this issue, we implemented a solution by only sending the orders with the latest action.