### PR TITLE
BAH-3583 | Fix. Incorrect Alpha Numeric String Parsing

### DIFF
--- a/openerp-client/pom.xml
+++ b/openerp-client/pom.xml
@@ -221,6 +221,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <finalName>openerp-client</finalName>

--- a/openerp-client/src/main/java/org/bahmni/openerp/web/request/builder/RequestBuilder.java
+++ b/openerp-client/src/main/java/org/bahmni/openerp/web/request/builder/RequestBuilder.java
@@ -3,6 +3,7 @@ package org.bahmni.openerp.web.request.builder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import freemarker.template.Template;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.bahmni.openerp.web.OpenERPException;
 import org.bahmni.openerp.web.config.FreeMarkerConfig;
 import org.bahmni.openerp.web.request.OpenERPRequest;
@@ -53,10 +54,21 @@ public class RequestBuilder {
     }
 
     private static Object parseParameterValue(String value) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(value, Object.class);
-        } catch (Exception e) {
+       if (value.startsWith("{") && value.endsWith("}")) {
+            try {
+                ObjectMapper mapper = new ObjectMapper();
+                return mapper.readValue(value, Object.class);
+            } catch (Exception e) {
+                return value;
+            }
+        } else {
+            if(NumberUtils.isCreatable(value)){
+                try {
+                    return NumberUtils.createNumber(value);
+                } catch (Exception e) {
+                    return value;
+                }
+            }
             return value;
         }
     }

--- a/openerp-client/src/test/java/org/bahmni/openerp/web/request/builder/RequestBuilderTest.java
+++ b/openerp-client/src/test/java/org/bahmni/openerp/web/request/builder/RequestBuilderTest.java
@@ -1,14 +1,10 @@
 package org.bahmni.openerp.web.request.builder;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bahmni.openerp.web.request.OpenERPRequest;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 
@@ -218,6 +214,54 @@ public class RequestBuilderTest {
         String expected = "{\"name\":\"कृपा\"}";
 
         Parameter parameter = new Parameter("name", name, "string");
+        ArrayList<Parameter> parameters = new ArrayList<Parameter>();
+        parameters.add(parameter);
+        OpenERPRequest request = new OpenERPRequest("res.partner", "execute", parameters);
+
+        String requestXml = RequestBuilder.buildNewRestRequest(request);
+
+        comparingStringWithoutSpaces(requestXml, expected);
+    }
+
+    @Test
+    public void shouldReturnStringEvenWhenRESTRequestStartsWithANumber() throws Exception {
+
+        String name = "6 - DENTAL - Surgical Extraction of tooth including LA - 1200 - D";
+        String expected = "{\"name\":\"6 - DENTAL - Surgical Extraction of tooth including LA - 1200 - D\"}";
+
+        Parameter parameter = new Parameter("name", name, "string");
+        ArrayList<Parameter> parameters = new ArrayList<Parameter>();
+        parameters.add(parameter);
+        OpenERPRequest request = new OpenERPRequest("res.partner", "execute", parameters);
+
+        String requestXml = RequestBuilder.buildNewRestRequest(request);
+
+        comparingStringWithoutSpaces(requestXml, expected);
+    }
+
+    @Test
+    public void shouldReturnNumberWhenRESTRequestIsANumber() throws Exception {
+
+        String number = "62380";
+        String expected = "{\"number\":62380}";
+
+        Parameter parameter = new Parameter("number", number, "string");
+        ArrayList<Parameter> parameters = new ArrayList<Parameter>();
+        parameters.add(parameter);
+        OpenERPRequest request = new OpenERPRequest("res.partner", "execute", parameters);
+
+        String requestXml = RequestBuilder.buildNewRestRequest(request);
+
+        comparingStringWithoutSpaces(requestXml, expected);
+    }
+
+    @Test
+    public void shouldReturnNumberWhenRESTRequestIsADecimal() throws Exception {
+
+        String number = "62380.9";
+        String expected = "{\"number\":62380.9}";
+
+        Parameter parameter = new Parameter("number", number, "string");
         ArrayList<Parameter> parameters = new ArrayList<Parameter>();
         parameters.add(parameter);
         OpenERPRequest request = new OpenERPRequest("res.partner", "execute", parameters);


### PR DESCRIPTION
JIRA -> [BAH-3583](https://bahmni.atlassian.net/browse/BAH-3583)

In this PR, the parseParameterValue method has been updated to handle different input cases accordingly. An issue was noticed when the input string was "6 - DENTAL - Surgical Extraction of tooth including LA - 1200 - D" but the output was 6, which didn't align with the expectation. Here, the input string  resembles a JSON object-like structure, starting with a numeric value. When parsed by the ObjectMapper, it interprets the input as a numeric value due to the initial digit. Consequently, it returns the parsed value as 6. 

This behavior is consistent with how the ObjectMapper operates based on the input provided. To ensure consistent behavior regardless of the input format, modification to the method is made to handle different cases accordingly.