### PR TITLE
BAH-3740 | Refactor. Initialize Sale Order Cron Expression From ENV

### DIFF
--- a/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/OpenERPAtomFeedProperties.java
+++ b/openerp-atomfeed-service/src/main/java/org/bahmni/feed/openerp/OpenERPAtomFeedProperties.java
@@ -21,6 +21,9 @@ public class OpenERPAtomFeedProperties implements OpenERPProperties {
     @Value("${scheduler.initial.delay:60000}")
     private String schedulerInitialDelay;
 
+    @Value("${scheduler.sale.order.cron.expression:0/30 * * * * ?}")
+    private String schedulerSaleOrderCronExpression;
+
     public String getSchedulerInitialDelay() {
         return schedulerInitialDelay;
     }
@@ -215,6 +218,7 @@ public class OpenERPAtomFeedProperties implements OpenERPProperties {
         HashMap<String, String> values = new HashMap<>();
         values.put("chunking.strategy",chunkingStrategy );
         values.put("scheduler.initial.delay", schedulerInitialDelay);
+        values.put("scheduler.sale.order.cron.expression", schedulerSaleOrderCronExpression);
         values.put("customer.feed.generator.uri",customFeedUri );
         values.put("openelis.saleorder.feed.generator.uri",elisSaleOrderFeedUri );
         values.put("drug.feed.generator.uri",drugFeedUri );

--- a/openerp-atomfeed-service/src/main/resources/erp-atomfeed.properties
+++ b/openerp-atomfeed-service/src/main/resources/erp-atomfeed.properties
@@ -49,5 +49,6 @@ openmrs.password=test
 openmrs.auth.uri=http://localhost:8050/openmrs/ws/rest/v1/session
 
 scheduler.initial.delay=60000
+scheduler.sale.order.cron.expression=0/30 * * * * ?
 
 referencedata.endpoint=http://localhost:8050/reference-data

--- a/openerp-atomfeed-service/src/main/resources/jobs-context.xml
+++ b/openerp-atomfeed-service/src/main/resources/jobs-context.xml
@@ -129,13 +129,13 @@
         <bean id="saleOrderFeedJobTrigger"
               class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
             <property name="jobDetail" ref="openerpSaleOrderFeedQuartzJob" />
-            <property name="cronExpression" value="0/30 * * * * ?" />
+            <property name="cronExpression" value="${scheduler.sale.order.cron.expression}" />
             <property name="startDelay" value="${scheduler.initial.delay}" />
         </bean>
         <bean id="saleOrderFeedFailedJobTrigger"
               class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
             <property name="jobDetail" ref="openerpSaleOrderFeedQuartzFailedJob" />
-            <property name="cronExpression" value="0/30 * * * * ?" />
+            <property name="cronExpression" value="${scheduler.sale.order.cron.expression}" />
             <property name="startDelay" value="${scheduler.initial.delay}" />
         </bean>
 

--- a/package/docker/templates/erp-atomfeed.properties.template
+++ b/package/docker/templates/erp-atomfeed.properties.template
@@ -48,5 +48,6 @@ openmrs.password=${OPENMRS_ATOMFEED_PASSWORD}
 openmrs.auth.uri=http://${OPENMRS_HOST}:${OPENMRS_PORT}/openmrs/ws/rest/v1/session
 
 scheduler.initial.delay=60000
+scheduler.sale.order.cron.expression=0/30 * * * * ?
 
 referencedata.endpoint=http://${OPENMRS_HOST}:${OPENMRS_PORT}/reference-data


### PR DESCRIPTION
JIRA -> [BAH-3740](https://bahmni.atlassian.net/browse/BAH-3740)

This PR addresses the task of refactoring the initialization process for the OpenMRS sale order cron expression. Previously, the cron expression was hardcoded, limiting flexibility and customization options. With this update, the code has been modified to allow the cron expression to be passed as an environment variable. In cases where the environment variable is not provided, the value is retrieved from the properties file.