### PR TITLE
Revert "Deepthi M| BAH-3932|Updated the versions of postgres and liquibase to resolve the vulnerabilities"

### DIFF
--- a/openerp-atomfeed-service/pom.xml
+++ b/openerp-atomfeed-service/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.6.1</version>
+            <version>42.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>4.28.0</version>
+            <version>3.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -272,7 +272,7 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>4.28.0</version>
+                <version>3.3.2</version>
                 <configuration>
                     <changeLogFile>src/main/resources/sql/db_migrations.xml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>


### PR DESCRIPTION
Reverts Bahmni/openerp-atomfeed-service#110 as the package upgrade causes the application to fail while running liquibase migrations during initialisation